### PR TITLE
Add smallstep_device_collection_account resource

### DIFF
--- a/docs/data-sources/collection.md
+++ b/docs/data-sources/collection.md
@@ -33,7 +33,6 @@ data "smallstep_collection" "tpms" {
 
 - `created_at` (String) Timestamp in RFC3339 format when the collections was created
 - `display_name` (String) A user-friendly name for the collection.
-- `id` (String) Internal use only
 - `instance_count` (Number) The number of instances in the collection.
 - `updated_at` (String) Timestamp in RFC3339 format when the collections was last updated
 

--- a/docs/resources/collection.md
+++ b/docs/resources/collection.md
@@ -33,7 +33,6 @@ resource "smallstep_collection" "tpms" {
 ### Read-Only
 
 - `created_at` (String) Timestamp in RFC3339 format when the collections was created
-- `id` (String) Internal use only
 - `instance_count` (Number) The number of instances in the collection.
 - `updated_at` (String) Timestamp in RFC3339 format when the collections was last updated
 

--- a/internal/provider/account/resource_test.go
+++ b/internal/provider/account/resource_test.go
@@ -32,7 +32,7 @@ var providerFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"smallstep": providerserver.NewProtocol6WithError(provider),
 }
 
-func TestAccWorkloadResource(t *testing.T) {
+func TestAccAccountResource(t *testing.T) {
 	t.Parallel()
 	const browsers = `
 resource "smallstep_account" "browsers" {

--- a/internal/provider/collection/data_source.go
+++ b/internal/provider/collection/data_source.go
@@ -111,10 +111,6 @@ func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, r
 		MarkdownDescription: component,
 
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Internal use only",
-				Computed:            true,
-			},
 			"slug": schema.StringAttribute{
 				MarkdownDescription: props["slug"],
 				Required:            true,

--- a/internal/provider/collection/model.go
+++ b/internal/provider/collection/model.go
@@ -20,8 +20,6 @@ type Model struct {
 	CreatedAt     types.String `tfsdk:"created_at"`
 	UpdatedAt     types.String `tfsdk:"updated_at"`
 	SchemaURI     types.String `tfsdk:"schema_uri"`
-	// https://developer.hashicorp.com/terraform/plugin/framework/acctests#implement-id-attribute
-	ID types.String `tfsdk:"id"`
 }
 
 func fromAPI(ctx context.Context, collection *v20231101.Collection, state utils.AttributeGetter) (*Model, diag.Diagnostics) {
@@ -40,7 +38,6 @@ func fromAPI(ctx context.Context, collection *v20231101.Collection, state utils.
 		SchemaURI:     schemaURI,
 		CreatedAt:     types.StringValue(collection.CreatedAt.Format(time.RFC3339)),
 		UpdatedAt:     types.StringValue(collection.UpdatedAt.Format(time.RFC3339)),
-		ID:            types.StringValue(collection.Slug),
 	}
 
 	return model, diags

--- a/internal/provider/collection/resource.go
+++ b/internal/provider/collection/resource.go
@@ -118,10 +118,6 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 		MarkdownDescription: component,
 
 		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				MarkdownDescription: "Internal use only",
-				Computed:            true,
-			},
 			"slug": schema.StringAttribute{
 				MarkdownDescription: props["slug"],
 				Required:            true,

--- a/internal/provider/collection/resource_test.go
+++ b/internal/provider/collection/resource_test.go
@@ -142,10 +142,11 @@ resource "smallstep_collection" "employees" {
 				},
 			},
 			{
-				ResourceName:      "smallstep_collection.employees",
-				ImportState:       true,
-				ImportStateId:     slug,
-				ImportStateVerify: true,
+				ResourceName:                         "smallstep_collection.employees",
+				ImportState:                          true,
+				ImportStateId:                        slug,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "slug",
 			},
 		},
 	})

--- a/internal/provider/device_collection_account/data_source.go
+++ b/internal/provider/device_collection_account/data_source.go
@@ -1,0 +1,184 @@
+package device_collection_account
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	v20231101 "github.com/smallstep/terraform-provider-smallstep/internal/apiclient/v20231101"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/workload"
+)
+
+var _ datasource.DataSource = &DataSource{}
+
+type DataSource struct {
+	client *v20231101.Client
+}
+
+func NewDataSource() datasource.DataSource {
+	return &DataSource{}
+}
+
+func (d *DataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = name
+}
+
+// Configure adds the Smallstep API client to the data source.
+func (d *DataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*v20231101.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Get Smallstep API client from provider",
+			fmt.Sprintf("Expected *v20231101.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	dca, props, err := utils.Describe("deviceCollectionAccount")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI Schema",
+			err.Error(),
+		)
+		return
+	}
+
+	certInfo, err := workload.NewCertificateInfoDataSourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	certData, err := workload.NewCertificateDataDataSourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+	}
+
+	keyInfo, err := workload.NewKeyInfoDataSourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	reloadInfo, err := workload.NewReloadInfoDataSourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Schema = schema.Schema{
+		MarkdownDescription: dca,
+
+		Attributes: map[string]schema.Attribute{
+			"device_collection_slug": schema.StringAttribute{
+				MarkdownDescription: props["deviceCollectionSlug"],
+				Required:            true,
+			},
+			"slug": schema.StringAttribute{
+				MarkdownDescription: props["slug"],
+				Required:            true,
+			},
+			"account_id": schema.StringAttribute{
+				MarkdownDescription: props["accountID"],
+				Optional:            true,
+			},
+			"authority_id": schema.StringAttribute{
+				MarkdownDescription: props["authorityID"],
+				Optional:            true,
+			},
+			"display_name": schema.StringAttribute{
+				MarkdownDescription: props["displayName"],
+				Optional:            true,
+			},
+			"certificate_info": certInfo,
+			"reload_info":      reloadInfo,
+			"certificate_data": certData,
+			"key_info":         keyInfo,
+		},
+	}
+}
+
+func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var slug string
+	var dcSlug string
+
+	ds := req.Config.GetAttribute(ctx, path.Root("slug"), &slug)
+	resp.Diagnostics.Append(ds...)
+	ds = req.Config.GetAttribute(ctx, path.Root("device_collection_slug"), &dcSlug)
+	resp.Diagnostics.Append(ds...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	httpResp, err := d.client.GetDeviceCollectionAccount(ctx, dcSlug, slug, &v20231101.GetDeviceCollectionAccountParams{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to read device collection account %q: %v", slug, err),
+		)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	switch httpResp.StatusCode {
+	case http.StatusOK:
+		break
+	case http.StatusNotFound:
+		resp.Diagnostics.AddError(
+			"Device Collection Account Not Found",
+			fmt.Sprintf("Device collection account %q data source not found", slug),
+		)
+		return
+	default:
+		reqID := httpResp.Header.Get("X-Request-Id")
+		resp.Diagnostics.AddError(
+			"Smallstep API Response Error",
+			fmt.Sprintf("Request %q received status %d reading device collection account %q: %s", reqID, httpResp.StatusCode, slug, utils.APIErrorMsg(httpResp.Body)),
+		)
+		return
+	}
+
+	dca := &v20231101.DeviceCollectionAccount{}
+	if err := json.NewDecoder(httpResp.Body).Decode(dca); err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to unmarshal device collection account %s: %v", slug, err),
+		)
+		return
+	}
+
+	remote, ds := fromAPI(ctx, dca, dcSlug, req.Config)
+	resp.Diagnostics.Append(ds...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &remote)...)
+}

--- a/internal/provider/device_collection_account/data_source_test.go
+++ b/internal/provider/device_collection_account/data_source_test.go
@@ -1,0 +1,37 @@
+package device_collection_account
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+)
+
+func TestAccDeviceCollectionAccountDataSource(t *testing.T) {
+	t.Parallel()
+	dca, dcSlug := utils.NewDeviceCollectionAccount(t)
+
+	config := fmt.Sprintf(`
+data "smallstep_device_collection_account" "tester" {
+	slug = %q
+	device_collection_slug = %q
+}
+`, dca.Slug, dcSlug)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.smallstep_device_collection_account.tester", "slug", dca.Slug),
+					resource.TestCheckResourceAttr("data.smallstep_device_collection_account.tester", "account_id", dca.AccountID),
+					resource.TestCheckResourceAttr("data.smallstep_device_collection_account.tester", "device_collection_slug", dcSlug),
+					resource.TestCheckResourceAttr("data.smallstep_device_collection_account.tester", "display_name", dca.DisplayName),
+					resource.TestCheckResourceAttr("data.smallstep_device_collection_account.tester", "authority_id", *dca.AuthorityID),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/device_collection_account/model.go
+++ b/internal/provider/device_collection_account/model.go
@@ -1,0 +1,104 @@
+package device_collection_account
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	v20231101 "github.com/smallstep/terraform-provider-smallstep/internal/apiclient/v20231101"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/workload"
+)
+
+const name = "smallstep_device_collection_account"
+
+type Model struct {
+	Slug                 types.String `tfsdk:"slug"`
+	AccountID            types.String `tfsdk:"account_id"`
+	DeviceCollectionSlug types.String `tfsdk:"device_collection_slug"`
+	AuthorityID          types.String `tfsdk:"authority_id"`
+	DisplayName          types.String `tfsdk:"display_name"`
+	CertificateInfo      types.Object `tfsdk:"certificate_info"`
+	KeyInfo              types.Object `tfsdk:"key_info"`
+	ReloadInfo           types.Object `tfsdk:"reload_info"`
+	CertificateData      types.Object `tfsdk:"certificate_data"`
+}
+
+func toAPI(ctx context.Context, model *Model) (*v20231101.DeviceCollectionAccount, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	reloadInfo := &workload.ReloadInfoModel{}
+	ds := model.ReloadInfo.As(ctx, &reloadInfo, basetypes.ObjectAsOptions{
+		UnhandledUnknownAsEmpty: true,
+	})
+	diags.Append(ds...)
+
+	certInfo := &workload.CertificateInfoModel{}
+	ds = model.CertificateInfo.As(ctx, &certInfo, basetypes.ObjectAsOptions{})
+	diags.Append(ds...)
+
+	keyInfo := &workload.KeyInfoModel{}
+	ds = model.KeyInfo.As(ctx, &keyInfo, basetypes.ObjectAsOptions{})
+	diags.Append(ds...)
+
+	dca := &v20231101.DeviceCollectionAccount{
+		Slug:            model.Slug.ValueString(),
+		AccountID:       model.AccountID.ValueString(),
+		AuthorityID:     model.AuthorityID.ValueStringPointer(),
+		DisplayName:     model.DisplayName.ValueString(),
+		CertificateInfo: certInfo.ToAPI(),
+		KeyInfo:         keyInfo.ToAPI(),
+		ReloadInfo:      reloadInfo.ToAPI(),
+	}
+
+	certDataModel := &workload.CertificateDataModel{}
+	diags = model.CertificateData.As(ctx, &certDataModel, basetypes.ObjectAsOptions{
+		UnhandledUnknownAsEmpty: true,
+	})
+	x509Fields, ds := certDataModel.ToAPI(ctx)
+	diags.Append(ds...)
+	err := dca.FromX509Fields(x509Fields)
+	if err != nil {
+		diags.AddError("Device Collection Account Certificate Data", err.Error())
+		return nil, diags
+	}
+
+	return dca, diags
+}
+
+func fromAPI(ctx context.Context, dca *v20231101.DeviceCollectionAccount, dcSlug string, state utils.AttributeGetter) (*Model, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	model := &Model{
+		Slug:                 types.StringValue(dca.Slug),
+		AccountID:            types.StringValue(dca.AccountID),
+		DeviceCollectionSlug: types.StringValue(dcSlug),
+		DisplayName:          types.StringValue(dca.DisplayName),
+		AuthorityID:          types.StringValue(utils.Deref(dca.AuthorityID)),
+	}
+
+	x509Fields, err := dca.AsX509Fields()
+	if err != nil {
+		diags.AddError("parse device collection account response", err.Error())
+		return nil, diags
+	}
+
+	certInfo, ds := workload.CertInfoFromAPI(ctx, dca.CertificateInfo, state)
+	diags.Append(ds...)
+	model.CertificateInfo = certInfo
+
+	certData, ds := workload.CertDataFromAPI(ctx, x509Fields, state)
+	diags.Append(ds...)
+	model.CertificateData = certData
+
+	keyInfo, ds := workload.KeyInfoFromAPI(ctx, dca.KeyInfo, state)
+	diags.Append(ds...)
+	model.KeyInfo = keyInfo
+
+	reloadInfo, ds := workload.ReloadInfoFromAPI(ctx, dca.ReloadInfo, state)
+	diags.Append(ds...)
+	model.ReloadInfo = reloadInfo
+
+	return model, diags
+}

--- a/internal/provider/device_collection_account/resource.go
+++ b/internal/provider/device_collection_account/resource.go
@@ -1,0 +1,332 @@
+package device_collection_account
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	v20231101 "github.com/smallstep/terraform-provider-smallstep/internal/apiclient/v20231101"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/workload"
+)
+
+var _ resource.ResourceWithImportState = (*Resource)(nil)
+
+func NewResource() resource.Resource {
+	return &Resource{}
+}
+
+// Resource defines the resource implementation.
+type Resource struct {
+	client *v20231101.Client
+}
+
+func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	dca, props, err := utils.Describe("deviceCollectionAccount")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI Schema",
+			err.Error(),
+		)
+		return
+	}
+
+	certInfo, err := workload.NewCertificateInfoResourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	certData, err := workload.NewCertificateDataResourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+	}
+
+	keyInfo, err := workload.NewKeyInfoResourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	reloadInfo, err := workload.NewReloadInfoResourceSchema()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Parse Smallstep OpenAPI spec",
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Schema = schema.Schema{
+		MarkdownDescription: dca,
+
+		Attributes: map[string]schema.Attribute{
+			"account_id": schema.StringAttribute{
+				MarkdownDescription: props["accountID"],
+				Required:            true,
+			},
+			"authority_id": schema.StringAttribute{
+				MarkdownDescription: props["authorityID"],
+				Required:            true,
+			},
+			"display_name": schema.StringAttribute{
+				MarkdownDescription: props["displayName"],
+				Required:            true,
+			},
+			"slug": schema.StringAttribute{
+				MarkdownDescription: props["slug"],
+				Required:            true,
+			},
+			"device_collection_slug": schema.StringAttribute{
+				MarkdownDescription: props["deviceCollectionSlug"],
+				Required:            true,
+			},
+			"certificate_info": certInfo,
+			"reload_info":      reloadInfo,
+			"certificate_data": certData,
+			"key_info":         keyInfo,
+		},
+	}
+}
+
+func (r *Resource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = name
+}
+
+// Configure adds the Smallstep API client to the resource.
+func (r *Resource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*v20231101.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Get Smallstep API client from provider",
+			fmt.Sprintf("Expected *v20231101.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	state := &Model{}
+
+	resp.Diagnostics.Append(req.State.Get(ctx, state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dcSlug := state.DeviceCollectionSlug.ValueString()
+	slug := state.Slug.ValueString()
+
+	httpResp, err := r.client.GetDeviceCollectionAccount(ctx, dcSlug, slug, &v20231101.GetDeviceCollectionAccountParams{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to read device collection account %q: %v", slug, err),
+		)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		reqID := httpResp.Header.Get("X-Request-Id")
+		resp.Diagnostics.AddError(
+			"Smallstep API Response Error",
+			fmt.Sprintf("Request %q received status %d reading device collection account %s: %s", reqID, httpResp.StatusCode, slug, utils.APIErrorMsg(httpResp.Body)),
+		)
+		return
+	}
+
+	dca := &v20231101.DeviceCollectionAccount{}
+	if err := json.NewDecoder(httpResp.Body).Decode(dca); err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to unmarshal device collection account %s: %v", slug, err),
+		)
+		return
+	}
+
+	remote, d := fromAPI(ctx, dca, dcSlug, req.State)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &remote)...)
+}
+
+func (a *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	plan := &Model{}
+	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	reqBody, diags := toAPI(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dcSlug := plan.DeviceCollectionSlug.ValueString()
+	slug := plan.Slug.ValueString()
+
+	httpResp, err := a.client.PutDeviceCollectionAccount(ctx, dcSlug, slug, &v20231101.PutDeviceCollectionAccountParams{}, *reqBody)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to create device collection account: %v", err),
+		)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		reqID := httpResp.Header.Get("X-Request-Id")
+		resp.Diagnostics.AddError(
+			"Smallstep API Response Error",
+			fmt.Sprintf("Request %q received status %d creating device collection account: %s", reqID, httpResp.StatusCode, utils.APIErrorMsg(httpResp.Body)),
+		)
+		return
+	}
+
+	dca := &v20231101.DeviceCollectionAccount{}
+	if err := json.NewDecoder(httpResp.Body).Decode(dca); err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to unmarshal device collection account: %v", err),
+		)
+		return
+	}
+
+	model, diags := fromAPI(ctx, dca, dcSlug, req.Plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, model)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	plan := &Model{}
+	resp.Diagnostics.Append(req.Plan.Get(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	reqBody, diags := toAPI(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dcSlug := plan.DeviceCollectionSlug.ValueString()
+	slug := plan.Slug.ValueString()
+
+	httpResp, err := r.client.PutDeviceCollectionAccount(ctx, dcSlug, slug, &v20231101.PutDeviceCollectionAccountParams{}, *reqBody)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to update device collection account: %v", err),
+		)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		reqID := httpResp.Header.Get("X-Request-Id")
+		resp.Diagnostics.AddError(
+			"Smallstep API Response Error",
+			fmt.Sprintf("Request %q received status %d creating device collection account: %s", reqID, httpResp.StatusCode, utils.APIErrorMsg(httpResp.Body)),
+		)
+		return
+	}
+
+	dca := &v20231101.DeviceCollectionAccount{}
+	if err := json.NewDecoder(httpResp.Body).Decode(dca); err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to unmarshal device collection account: %v", err),
+		)
+		return
+	}
+
+	model, diags := fromAPI(ctx, dca, dcSlug, req.Plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diags = resp.State.Set(ctx, model)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	state := &Model{}
+	diags := req.State.Get(ctx, state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dcSlug := state.DeviceCollectionSlug.ValueString()
+	slug := state.Slug.ValueString()
+
+	httpResp, err := r.client.DeleteDeviceCollectionAccount(ctx, dcSlug, slug, &v20231101.DeleteDeviceCollectionAccountParams{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Smallstep API Client Error",
+			fmt.Sprintf("Failed to delete device collection account: %v", err),
+		)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusNoContent {
+		reqID := httpResp.Header.Get("X-Request-Id")
+		resp.Diagnostics.AddError(
+			"Smallstep API Response Error",
+			fmt.Sprintf("Request %q received status %d deleting device collection account: %s", reqID, httpResp.StatusCode, utils.APIErrorMsg(httpResp.Body)),
+		)
+		return
+	}
+}
+
+func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Invalid import ID",
+			`Import ID must be "<device collection slug>/<slug>"`,
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("device_collection_slug"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("slug"), parts[1])...)
+}

--- a/internal/provider/device_collection_account/resource_test.go
+++ b/internal/provider/device_collection_account/resource_test.go
@@ -1,0 +1,127 @@
+package device_collection_account
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	helper "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+	"github.com/smallstep/terraform-provider-smallstep/internal/testprovider"
+)
+
+func TestMain(m *testing.M) {
+	helper.TestMain(m)
+}
+
+var provider = &testprovider.SmallstepTestProvider{
+	ResourceFactories: []func() resource.Resource{
+		NewResource,
+	},
+	DataSourceFactories: []func() datasource.DataSource{
+		NewDataSource,
+	},
+}
+
+var providerFactories = map[string]func() (tfprotov6.ProviderServer, error){
+	"smallstep": providerserver.NewProtocol6WithError(provider),
+}
+
+func TestAccAccountResource(t *testing.T) {
+	t.Parallel()
+
+	dc := utils.NewTPMDeviceCollection(t)
+	account, _ := utils.NewAccount(t)
+	authority := utils.NewAuthority(t)
+	slug := utils.Slug(t)
+
+	config := fmt.Sprintf(`
+resource "smallstep_device_collection_account" "test" {
+	slug = %q
+	device_collection_slug = %q
+	account_id = %q
+	authority_id = %q
+	display_name = "Tester"
+	certificate_info = {
+		type = "X509"
+	}
+	key_info = {
+		type = "ECDSA_P256"
+		protection = "HARDWARE"
+		format = "DEFAULT"
+	}
+	certificate_data = {
+		common_name = {
+			device_metadata = "email"
+		}
+		sans = {
+			device_metadata = ["email"]
+		}
+	}
+}`, slug, dc.Slug, *account.Id, authority.Id)
+
+	config2 := fmt.Sprintf(`
+resource "smallstep_device_collection_account" "test" {
+	slug = %q
+	device_collection_slug = %q
+	account_id = %q
+	authority_id = %q
+	display_name = "Tester 2"
+	certificate_info = {
+		type = "X509"
+	}
+	key_info = {
+		type = "ECDSA_P256"
+		protection = "HARDWARE"
+		format = "DEFAULT"
+	}
+	certificate_data = {
+		common_name = {
+			device_metadata = "email"
+		}
+		sans = {
+			device_metadata = ["email"]
+		}
+	}
+}`, slug, dc.Slug, *account.Id, authority.Id)
+
+	helper.Test(t, helper.TestCase{
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []helper.TestStep{
+			{
+				Config: config,
+				ConfigPlanChecks: helper.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("smallstep_device_collection_account.test", plancheck.ResourceActionCreate),
+					},
+				},
+				Check: helper.ComposeAggregateTestCheckFunc(
+					helper.TestCheckResourceAttr("smallstep_device_collection_account.test", "slug", slug),
+					helper.TestCheckResourceAttr("smallstep_device_collection_account.test", "display_name", "Tester"),
+				),
+			},
+			{
+				Config: config2,
+				ConfigPlanChecks: helper.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("smallstep_device_collection_account.test", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: helper.ComposeAggregateTestCheckFunc(
+					helper.TestCheckResourceAttr("smallstep_device_collection_account.test", "display_name", "Tester 2"),
+				),
+			},
+			{
+				ResourceName:                         "smallstep_device_collection_account.test",
+				ImportState:                          true,
+				ImportStateId:                        fmt.Sprintf("%s/%s", dc.Slug, slug),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "slug",
+			},
+		},
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/collection"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/collection_instance"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/device_collection"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/device_collection_account"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/provisioner"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/webhook"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/workload"
@@ -179,6 +180,7 @@ func (p *SmallstepProvider) Resources(ctx context.Context) []func() resource.Res
 		device_collection.NewResource,
 		workload.NewResource,
 		account.NewResource,
+		device_collection_account.NewResource,
 	}
 }
 
@@ -191,6 +193,7 @@ func (p *SmallstepProvider) DataSources(ctx context.Context) []func() datasource
 		attestation_authority.NewDataSource,
 		webhook.NewDataSource,
 		account.NewDataSource,
+		device_collection_account.NewDataSource,
 	}
 }
 

--- a/internal/provider/workload/data_source.go
+++ b/internal/provider/workload/data_source.go
@@ -1,0 +1,249 @@
+package workload
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
+)
+
+func NewCertificateInfoDataSourceSchema() (schema.SingleNestedAttribute, error) {
+	certInfo, certInfoProps, err := utils.Describe("endpointCertificateInfo")
+	if err != nil {
+		return schema.SingleNestedAttribute{}, err
+	}
+
+	out := schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: certInfo,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				MarkdownDescription: certInfoProps["type"],
+				Optional:            true,
+			},
+			"duration": schema.StringAttribute{
+				MarkdownDescription: certInfoProps["duration"],
+				Optional:            true,
+			},
+			"crt_file": schema.StringAttribute{
+				MarkdownDescription: certInfoProps["crtFile"],
+				Optional:            true,
+			},
+			"key_file": schema.StringAttribute{
+				MarkdownDescription: certInfoProps["keyFile"],
+				Optional:            true,
+			},
+			"root_file": schema.StringAttribute{
+				MarkdownDescription: certInfoProps["rootFile"],
+				Optional:            true,
+			},
+			"uid": schema.Int64Attribute{
+				MarkdownDescription: certInfoProps["uid"],
+				Optional:            true,
+			},
+			"gid": schema.Int64Attribute{
+				MarkdownDescription: certInfoProps["gid"],
+				Optional:            true,
+			},
+			"mode": schema.Int64Attribute{
+				MarkdownDescription: certInfoProps["mode"],
+				Optional:            true,
+			},
+		},
+	}
+
+	return out, nil
+}
+
+func NewCertificateDataDataSourceSchema() (schema.SingleNestedAttribute, error) {
+	certData, _, err := utils.Describe("x509Fields")
+	if err != nil {
+		return schema.SingleNestedAttribute{}, err
+	}
+
+	out := schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: certData,
+		Attributes: map[string]schema.Attribute{
+			"common_name": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.StringAttribute{
+						Optional: true,
+					},
+					"device_metadata": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			"sans": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"organization": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"organizational_unit": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"locality": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"country": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"province": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"street_address": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+			"postal_code": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"static": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+					"device_metadata": schema.ListAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+					},
+				},
+			},
+		},
+	}
+	return out, nil
+}
+
+func NewKeyInfoDataSourceSchema() (schema.SingleNestedAttribute, error) {
+	keyInfo, keyInfoProps, err := utils.Describe("endpointKeyInfo")
+	if err != nil {
+		return schema.SingleNestedAttribute{}, err
+	}
+
+	out := schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: keyInfo,
+		Attributes: map[string]schema.Attribute{
+			"type": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: keyInfoProps["type"],
+			},
+			"format": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: keyInfoProps["format"],
+			},
+			"pub_file": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: keyInfoProps["pubFile"],
+			},
+			"protection": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: keyInfoProps["protection"],
+			},
+		},
+	}
+
+	return out, nil
+}
+
+func NewReloadInfoDataSourceSchema() (schema.SingleNestedAttribute, error) {
+	reloadInfo, reloadInfoProps, err := utils.Describe("endpointReloadInfo")
+	if err != nil {
+		return schema.SingleNestedAttribute{}, err
+	}
+
+	out := schema.SingleNestedAttribute{
+		Optional:            true,
+		MarkdownDescription: reloadInfo,
+		Attributes: map[string]schema.Attribute{
+			"method": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: reloadInfoProps["method"],
+			},
+			"pid_file": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: reloadInfoProps["pidFile"],
+			},
+			"signal": schema.Int64Attribute{
+				Optional:            true,
+				MarkdownDescription: reloadInfoProps["signal"],
+			},
+			"unit_name": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: reloadInfoProps["unitName"],
+			},
+		},
+	}
+
+	return out, nil
+}

--- a/internal/provider/workload/model.go
+++ b/internal/provider/workload/model.go
@@ -15,19 +15,17 @@ import (
 const typeName = "smallstep_workload"
 
 type Model struct {
-	ID                   types.String          `tfsdk:"id"`
-	WorkloadType         types.String          `tfsdk:"workload_type"`
-	DisplayName          types.String          `tfsdk:"display_name"`
-	Slug                 types.String          `tfsdk:"slug"`
-	DeviceCollectionSlug types.String          `tfsdk:"device_collection_slug"`
-	CertificateInfo      *CertificateInfoModel `tfsdk:"certificate_info"`
-	KeyInfo              *KeyInfoModel         `tfsdk:"key_info"`
-	// ReloadInfo and Hooks are optional. Need to use Object type to support
-	// the "unknown" state.
-	ReloadInfo      types.Object `tfsdk:"reload_info"`
-	Hooks           types.Object `tfsdk:"hooks"`
-	AdminEmails     types.Set    `tfsdk:"admin_emails"`
-	CertificateData types.Object `tfsdk:"certificate_data"`
+	ID                   types.String `tfsdk:"id"`
+	WorkloadType         types.String `tfsdk:"workload_type"`
+	DisplayName          types.String `tfsdk:"display_name"`
+	Slug                 types.String `tfsdk:"slug"`
+	DeviceCollectionSlug types.String `tfsdk:"device_collection_slug"`
+	CertificateInfo      types.Object `tfsdk:"certificate_info"`
+	KeyInfo              types.Object `tfsdk:"key_info"`
+	ReloadInfo           types.Object `tfsdk:"reload_info"`
+	Hooks                types.Object `tfsdk:"hooks"`
+	AdminEmails          types.Set    `tfsdk:"admin_emails"`
+	CertificateData      types.Object `tfsdk:"certificate_data"`
 }
 
 type CertificateField struct {
@@ -84,218 +82,9 @@ var certificateDataType = types.ObjectType{
 	},
 }
 
-func fromAPI(ctx context.Context, workload *v20231101.Workload, state utils.AttributeGetter) (*Model, diag.Diagnostics) {
+func (certDataModel CertificateDataModel) ToAPI(ctx context.Context) (v20231101.X509Fields, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	ciDuration, d := utils.ToEqualString(ctx, workload.CertificateInfo.Duration, state, path.Root("certificate_info").AtName("duration"), utils.IsDurationEqual)
-	diags = append(diags, d...)
-
-	ciCrtFile, d := utils.ToOptionalString(ctx, workload.CertificateInfo.CrtFile, state, path.Root("certificate_info").AtName("crt_file"))
-	diags = append(diags, d...)
-
-	ciKeyFile, d := utils.ToOptionalString(ctx, workload.CertificateInfo.KeyFile, state, path.Root("certificate_info").AtName("key_file"))
-	diags = append(diags, d...)
-
-	ciRootFile, d := utils.ToOptionalString(ctx, workload.CertificateInfo.RootFile, state, path.Root("certificate_info").AtName("root_file"))
-	diags = append(diags, d...)
-
-	ciUID, d := utils.ToOptionalInt(ctx, workload.CertificateInfo.Uid, state, path.Root("certificate_info").AtName("uid"))
-	diags = append(diags, d...)
-
-	ciGID, d := utils.ToOptionalInt(ctx, workload.CertificateInfo.Gid, state, path.Root("certificate_info").AtName("gid"))
-	diags = append(diags, d...)
-
-	ciMode, d := utils.ToOptionalInt(ctx, workload.CertificateInfo.Mode, state, path.Root("certificate_info").AtName("mode"))
-	diags = append(diags, d...)
-
-	model := &Model{
-		ID:           types.StringValue(workload.Slug),
-		Slug:         types.StringValue(workload.Slug),
-		WorkloadType: types.StringValue(workload.WorkloadType),
-		DisplayName:  types.StringValue(workload.DisplayName),
-		CertificateInfo: &CertificateInfoModel{
-			Type:     types.StringValue(string(workload.CertificateInfo.Type)),
-			Duration: ciDuration,
-			CrtFile:  ciCrtFile,
-			KeyFile:  ciKeyFile,
-			RootFile: ciRootFile,
-			UID:      ciUID,
-			GID:      ciGID,
-			Mode:     ciMode,
-		},
-	}
-
-	if workload.Hooks != nil {
-		sign, d := HookFromAPI(ctx, workload.Hooks.Sign, path.Root("hooks").AtName("sign"), state)
-		diags.Append(d...)
-
-		renew, d := HookFromAPI(ctx, workload.Hooks.Renew, path.Root("hooks").AtName("renew"), state)
-		diags.Append(d...)
-
-		hooksObj, d := basetypes.NewObjectValue(HooksObjectType, map[string]attr.Value{
-			"sign":  sign,
-			"renew": renew,
-		})
-		diags.Append(d...)
-
-		model.Hooks = hooksObj
-	} else {
-		model.Hooks = basetypes.NewObjectNull(HooksObjectType)
-	}
-
-	if workload.KeyInfo != nil {
-		format, d := utils.ToOptionalString(ctx, workload.KeyInfo.Format, state, path.Root("key_info").AtName("format"))
-		diags = append(diags, d...)
-
-		pubFile, d := utils.ToOptionalString(ctx, workload.KeyInfo.PubFile, state, path.Root("key_info").AtName("pub_file"))
-		diags = append(diags, d...)
-
-		typ, d := utils.ToOptionalString(ctx, workload.KeyInfo.Type, state, path.Root("key_info").AtName("type"))
-		diags = append(diags, d...)
-
-		protection, d := utils.ToOptionalString(ctx, workload.KeyInfo.Protection, state, path.Root("key_info").AtName("protection"))
-		diags = append(diags, d...)
-
-		model.KeyInfo = &KeyInfoModel{
-			Format:     format,
-			PubFile:    pubFile,
-			Type:       typ,
-			Protection: protection,
-		}
-	}
-
-	if workload.ReloadInfo != nil {
-		pidFile, d := utils.ToOptionalString(ctx, workload.ReloadInfo.PidFile, state, path.Root("reload_info").AtName("method"))
-		diags.Append(d...)
-
-		signal, d := utils.ToOptionalInt(ctx, workload.ReloadInfo.Signal, state, path.Root("reload_info").AtName("signal"))
-		diags.Append(d...)
-
-		unitName, d := utils.ToOptionalString(ctx, workload.ReloadInfo.UnitName, state, path.Root("reload_info").AtName("unit_name"))
-		diags.Append(d...)
-
-		reloadInfoObject, d := basetypes.NewObjectValue(ReloadInfoType, map[string]attr.Value{
-			"method":    types.StringValue(string(workload.ReloadInfo.Method)),
-			"pid_file":  pidFile,
-			"signal":    signal,
-			"unit_name": unitName,
-		})
-		diags.Append(d...)
-		model.ReloadInfo = reloadInfoObject
-	} else {
-		model.ReloadInfo = basetypes.NewObjectNull(ReloadInfoType)
-	}
-
-	x509Fields, err := workload.AsX509Fields()
-	if err != nil {
-		diags.AddError("parse workload response", err.Error())
-		return nil, diags
-	}
-
-	cn := basetypes.NewObjectNull(certificateFieldType.AttrTypes)
-	if x509Fields.CommonName != nil {
-		cfStatic, err := x509Fields.CommonName.AsCertificateFieldStatic()
-		if err != nil {
-			diags.AddError("parse static common name", err.Error())
-			return nil, diags
-		}
-		cfDeviceMetadata, err := x509Fields.CommonName.AsCertificateFieldDeviceMetadata()
-		if err != nil {
-			diags.AddError("parse device metadata common name", err.Error())
-			return nil, diags
-		}
-		static, d := utils.ToOptionalString(ctx, &cfStatic.Static, state, path.Root("certificate_data").AtName("common_name").AtName("static"))
-		diags.Append(d...)
-		dm, d := utils.ToOptionalString(ctx, &cfDeviceMetadata.DeviceMetadata, state, path.Root("certificate_data").AtName("common_name").AtName("device_metadata"))
-		cn, d = basetypes.NewObjectValue(certificateFieldType.AttrTypes, map[string]attr.Value{
-			"static":          static,
-			"device_metadata": dm,
-		})
-		diags.Append(d...)
-		if diags.HasError() {
-			return nil, diags
-		}
-	}
-
-	sans, d := CertificateFieldListFromAPI(ctx, x509Fields.Sans, state, path.Root("certificate_data").AtName("sans"))
-	diags.Append(d...)
-
-	org, d := CertificateFieldListFromAPI(ctx, x509Fields.Organization, state, path.Root("certificate_data").AtName("organization"))
-	diags.Append(d...)
-
-	ou, d := CertificateFieldListFromAPI(ctx, x509Fields.OrganizationalUnit, state, path.Root("certificate_data").AtName("organizational_unit"))
-	diags.Append(d...)
-
-	locality, d := CertificateFieldListFromAPI(ctx, x509Fields.Locality, state, path.Root("certificate_data").AtName("locality"))
-	diags.Append(d...)
-
-	province, d := CertificateFieldListFromAPI(ctx, x509Fields.Province, state, path.Root("certificate_data").AtName("province"))
-	diags.Append(d...)
-
-	street, d := CertificateFieldListFromAPI(ctx, x509Fields.StreetAddress, state, path.Root("certificate_data").AtName("street_address"))
-	diags.Append(d...)
-
-	postal, d := CertificateFieldListFromAPI(ctx, x509Fields.PostalCode, state, path.Root("certificate_data").AtName("postal_code"))
-	diags.Append(d...)
-
-	country, d := CertificateFieldListFromAPI(ctx, x509Fields.Country, state, path.Root("certificate_data").AtName("country"))
-	diags.Append(d...)
-
-	certData, d := basetypes.NewObjectValue(certificateDataType.AttrTypes, map[string]attr.Value{
-		"common_name":         cn,
-		"sans":                sans,
-		"organization":        org,
-		"organizational_unit": ou,
-		"locality":            locality,
-		"province":            province,
-		"street_address":      street,
-		"postal_code":         postal,
-		"country":             country,
-	})
-	diags.Append(d...)
-	if diags.HasError() {
-		return nil, diags
-	}
-
-	model.CertificateData = certData
-
-	return model, diags
-}
-
-func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnostics) {
-	hooksModel := &HooksModel{}
-	diags := model.Hooks.As(ctx, &hooksModel, basetypes.ObjectAsOptions{
-		UnhandledUnknownAsEmpty: true,
-	})
-	hooks, d := hooksModel.ToAPI(ctx)
-	diags.Append(d...)
-
-	reloadInfo := &ReloadInfoModel{}
-	d = model.ReloadInfo.As(ctx, &reloadInfo, basetypes.ObjectAsOptions{
-		UnhandledUnknownAsEmpty: true,
-	})
-	diags.Append(d...)
-
-	var adminEmails []string
-	diags.Append(model.AdminEmails.ElementsAs(ctx, &adminEmails, false)...)
-
-	ci := model.CertificateInfo.ToAPI()
-
-	workload := &v20231101.Workload{
-		DisplayName:     model.DisplayName.ValueString(),
-		WorkloadType:    model.WorkloadType.ValueString(),
-		Slug:            model.Slug.ValueString(),
-		CertificateInfo: &ci,
-		KeyInfo:         model.KeyInfo.ToAPI(),
-		Hooks:           hooks,
-		ReloadInfo:      reloadInfo.ToAPI(),
-		AdminEmails:     &adminEmails,
-	}
-
-	certDataModel := &CertificateDataModel{}
-	diags = model.CertificateData.As(ctx, &certDataModel, basetypes.ObjectAsOptions{
-		UnhandledUnknownAsEmpty: true,
-	})
 	cn := &CertificateField{}
 	diags = certDataModel.CommonName.As(ctx, &cn, basetypes.ObjectAsOptions{
 		UnhandledUnknownAsEmpty: true,
@@ -341,7 +130,7 @@ func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnos
 			})
 			if err != nil {
 				diags.AddError("workload static common name", err.Error())
-				return nil, diags
+				return v20231101.X509Fields{}, diags
 			}
 		} else if cn.DeviceMetadata.ValueString() != "" {
 			err := cnField.FromCertificateFieldDeviceMetadata(v20231101.CertificateFieldDeviceMetadata{
@@ -349,7 +138,7 @@ func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnos
 			})
 			if err != nil {
 				diags.AddError("workload device metadata common name", err.Error())
-				return nil, diags
+				return v20231101.X509Fields{}, diags
 			}
 		}
 	}
@@ -378,7 +167,7 @@ func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnos
 	streetCFL, d := toCertificateFieldList(ctx, street)
 	diags.Append(d...)
 
-	err := workload.FromX509Fields(v20231101.X509Fields{
+	return v20231101.X509Fields{
 		CommonName:         cnField,
 		Sans:               sansCFL,
 		Country:            countryCFL,
@@ -388,7 +177,268 @@ func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnos
 		PostalCode:         postalCFL,
 		Province:           provinceCFL,
 		StreetAddress:      streetCFL,
+	}, diags
+}
+
+func fromAPI(ctx context.Context, workload *v20231101.Workload, state utils.AttributeGetter) (*Model, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	certInfo, ds := CertInfoFromAPI(ctx, workload.CertificateInfo, state)
+	diags.Append(ds...)
+
+	keyInfo, ds := KeyInfoFromAPI(ctx, workload.KeyInfo, state)
+	diags.Append(ds...)
+
+	reloadInfo, ds := ReloadInfoFromAPI(ctx, workload.ReloadInfo, state)
+	diags.Append(ds...)
+
+	model := &Model{
+		ID:              types.StringValue(workload.Slug),
+		Slug:            types.StringValue(workload.Slug),
+		WorkloadType:    types.StringValue(workload.WorkloadType),
+		DisplayName:     types.StringValue(workload.DisplayName),
+		CertificateInfo: certInfo,
+		KeyInfo:         keyInfo,
+		ReloadInfo:      reloadInfo,
+	}
+
+	if workload.Hooks != nil {
+		sign, d := HookFromAPI(ctx, workload.Hooks.Sign, path.Root("hooks").AtName("sign"), state)
+		diags.Append(d...)
+
+		renew, d := HookFromAPI(ctx, workload.Hooks.Renew, path.Root("hooks").AtName("renew"), state)
+		diags.Append(d...)
+
+		hooksObj, d := basetypes.NewObjectValue(HooksObjectType, map[string]attr.Value{
+			"sign":  sign,
+			"renew": renew,
+		})
+		diags.Append(d...)
+
+		model.Hooks = hooksObj
+	} else {
+		model.Hooks = basetypes.NewObjectNull(HooksObjectType)
+	}
+
+	x509Fields, err := workload.AsX509Fields()
+	if err != nil {
+		diags.AddError("parse workload response", err.Error())
+		return nil, diags
+	}
+
+	certData, ds := CertDataFromAPI(ctx, x509Fields, state)
+	diags.Append(ds...)
+
+	model.CertificateData = certData
+
+	return model, diags
+}
+
+func ReloadInfoFromAPI(ctx context.Context, reloadInfo *v20231101.EndpointReloadInfo, state utils.AttributeGetter) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	pidFile, d := utils.ToOptionalString(ctx, reloadInfo.PidFile, state, path.Root("reload_info").AtName("method"))
+	diags.Append(d...)
+
+	signal, d := utils.ToOptionalInt(ctx, reloadInfo.Signal, state, path.Root("reload_info").AtName("signal"))
+	diags.Append(d...)
+
+	unitName, d := utils.ToOptionalString(ctx, reloadInfo.UnitName, state, path.Root("reload_info").AtName("unit_name"))
+	diags.Append(d...)
+
+	out, d := basetypes.NewObjectValue(reloadInfoAttrTypes, map[string]attr.Value{
+		"method":    types.StringValue(string(reloadInfo.Method)),
+		"pid_file":  pidFile,
+		"signal":    signal,
+		"unit_name": unitName,
 	})
+	diags.Append(d...)
+
+	return out, diags
+}
+
+func KeyInfoFromAPI(ctx context.Context, keyInfo *v20231101.EndpointKeyInfo, state utils.AttributeGetter) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if keyInfo == nil {
+		return basetypes.NewObjectNull(keyInfoAttrTypes), diags
+	}
+
+	format, ds := utils.ToOptionalString(ctx, keyInfo.Format, state, path.Root("key_info").AtName("format"))
+	diags.Append(ds...)
+
+	pubFile, ds := utils.ToOptionalString(ctx, keyInfo.PubFile, state, path.Root("key_info").AtName("pub_file"))
+	diags.Append(ds...)
+
+	typ, ds := utils.ToOptionalString(ctx, keyInfo.Type, state, path.Root("key_info").AtName("type"))
+	diags.Append(ds...)
+
+	protection, ds := utils.ToOptionalString(ctx, keyInfo.Protection, state, path.Root("key_info").AtName("protection"))
+	diags.Append(ds...)
+
+	out, ds := basetypes.NewObjectValue(keyInfoAttrTypes, map[string]attr.Value{
+		"format":     format,
+		"pub_file":   pubFile,
+		"type":       typ,
+		"protection": protection,
+	})
+	diags.Append(ds...)
+
+	return out, diags
+}
+
+func CertInfoFromAPI(ctx context.Context, certInfo *v20231101.EndpointCertificateInfo, state utils.AttributeGetter) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	dur, d := utils.ToEqualString(ctx, certInfo.Duration, state, path.Root("certificate_info").AtName("duration"), utils.IsDurationEqual)
+	diags = append(diags, d...)
+
+	crtFile, d := utils.ToOptionalString(ctx, certInfo.CrtFile, state, path.Root("certificate_info").AtName("crt_file"))
+	diags = append(diags, d...)
+
+	keyFile, d := utils.ToOptionalString(ctx, certInfo.KeyFile, state, path.Root("certificate_info").AtName("key_file"))
+	diags = append(diags, d...)
+
+	rootFile, d := utils.ToOptionalString(ctx, certInfo.RootFile, state, path.Root("certificate_info").AtName("root_file"))
+	diags = append(diags, d...)
+
+	uid, d := utils.ToOptionalInt(ctx, certInfo.Uid, state, path.Root("certificate_info").AtName("uid"))
+	diags = append(diags, d...)
+
+	gid, d := utils.ToOptionalInt(ctx, certInfo.Gid, state, path.Root("certificate_info").AtName("gid"))
+	diags = append(diags, d...)
+
+	mode, d := utils.ToOptionalInt(ctx, certInfo.Mode, state, path.Root("certificate_info").AtName("mode"))
+	diags = append(diags, d...)
+
+	out, d := basetypes.NewObjectValue(certInfoAttrTypes, map[string]attr.Value{
+		"type":      types.StringValue(string(certInfo.Type)),
+		"crt_file":  crtFile,
+		"key_file":  keyFile,
+		"root_file": rootFile,
+		"duration":  dur,
+		"gid":       gid,
+		"uid":       uid,
+		"mode":      mode,
+	})
+	diags.Append(d...)
+
+	return out, diags
+}
+
+func CertDataFromAPI(ctx context.Context, x509Fields v20231101.X509Fields, state utils.AttributeGetter) (types.Object, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	cn := basetypes.NewObjectNull(certificateFieldType.AttrTypes)
+	if x509Fields.CommonName != nil {
+		cfStatic, err := x509Fields.CommonName.AsCertificateFieldStatic()
+		if err != nil {
+			diags.AddError("parse static common name", err.Error())
+			return types.Object{}, diags
+		}
+		cfDeviceMetadata, err := x509Fields.CommonName.AsCertificateFieldDeviceMetadata()
+		if err != nil {
+			diags.AddError("parse device metadata common name", err.Error())
+			return types.Object{}, diags
+		}
+		static, d := utils.ToOptionalString(ctx, &cfStatic.Static, state, path.Root("certificate_data").AtName("common_name").AtName("static"))
+		diags.Append(d...)
+		dm, d := utils.ToOptionalString(ctx, &cfDeviceMetadata.DeviceMetadata, state, path.Root("certificate_data").AtName("common_name").AtName("device_metadata"))
+		diags.Append(d...)
+		cn, d = basetypes.NewObjectValue(certificateFieldType.AttrTypes, map[string]attr.Value{
+			"static":          static,
+			"device_metadata": dm,
+		})
+		diags.Append(d...)
+		if diags.HasError() {
+			return types.Object{}, diags
+		}
+	}
+
+	sans, d := CertificateFieldListFromAPI(ctx, x509Fields.Sans, state, path.Root("certificate_data").AtName("sans"))
+	diags.Append(d...)
+
+	org, d := CertificateFieldListFromAPI(ctx, x509Fields.Organization, state, path.Root("certificate_data").AtName("organization"))
+	diags.Append(d...)
+
+	ou, d := CertificateFieldListFromAPI(ctx, x509Fields.OrganizationalUnit, state, path.Root("certificate_data").AtName("organizational_unit"))
+	diags.Append(d...)
+
+	locality, d := CertificateFieldListFromAPI(ctx, x509Fields.Locality, state, path.Root("certificate_data").AtName("locality"))
+	diags.Append(d...)
+
+	province, d := CertificateFieldListFromAPI(ctx, x509Fields.Province, state, path.Root("certificate_data").AtName("province"))
+	diags.Append(d...)
+
+	street, d := CertificateFieldListFromAPI(ctx, x509Fields.StreetAddress, state, path.Root("certificate_data").AtName("street_address"))
+	diags.Append(d...)
+
+	postal, d := CertificateFieldListFromAPI(ctx, x509Fields.PostalCode, state, path.Root("certificate_data").AtName("postal_code"))
+	diags.Append(d...)
+
+	country, d := CertificateFieldListFromAPI(ctx, x509Fields.Country, state, path.Root("certificate_data").AtName("country"))
+	diags.Append(d...)
+
+	certData, d := basetypes.NewObjectValue(certificateDataType.AttrTypes, map[string]attr.Value{
+		"common_name":         cn,
+		"sans":                sans,
+		"organization":        org,
+		"organizational_unit": ou,
+		"locality":            locality,
+		"province":            province,
+		"street_address":      street,
+		"postal_code":         postal,
+		"country":             country,
+	})
+	diags.Append(d...)
+
+	return certData, diags
+}
+
+func toAPI(ctx context.Context, model *Model) (*v20231101.Workload, diag.Diagnostics) {
+	hooksModel := &HooksModel{}
+	diags := model.Hooks.As(ctx, &hooksModel, basetypes.ObjectAsOptions{
+		UnhandledUnknownAsEmpty: true,
+	})
+	hooks, d := hooksModel.ToAPI(ctx)
+	diags.Append(d...)
+
+	reloadInfo := &ReloadInfoModel{}
+	d = model.ReloadInfo.As(ctx, &reloadInfo, basetypes.ObjectAsOptions{
+		UnhandledUnknownAsEmpty: true,
+	})
+	diags.Append(d...)
+
+	var adminEmails []string
+	diags.Append(model.AdminEmails.ElementsAs(ctx, &adminEmails, false)...)
+
+	ci := &CertificateInfoModel{}
+	d = model.CertificateInfo.As(ctx, &ci, basetypes.ObjectAsOptions{})
+	diags.Append(d...)
+
+	keyInfo := &KeyInfoModel{}
+	d = model.KeyInfo.As(ctx, &keyInfo, basetypes.ObjectAsOptions{})
+	diags.Append(d...)
+
+	workload := &v20231101.Workload{
+		DisplayName:     model.DisplayName.ValueString(),
+		WorkloadType:    model.WorkloadType.ValueString(),
+		Slug:            model.Slug.ValueString(),
+		CertificateInfo: ci.ToAPI(),
+		KeyInfo:         keyInfo.ToAPI(),
+		Hooks:           hooks,
+		ReloadInfo:      reloadInfo.ToAPI(),
+		AdminEmails:     &adminEmails,
+	}
+
+	certDataModel := &CertificateDataModel{}
+	diags = model.CertificateData.As(ctx, &certDataModel, basetypes.ObjectAsOptions{
+		UnhandledUnknownAsEmpty: true,
+	})
+	x509Fields, ds := certDataModel.ToAPI(ctx)
+	diags.Append(ds...)
+
+	err := workload.FromX509Fields(x509Fields)
 	if err != nil {
 		diags.AddError("workload certificate data", err.Error())
 		return nil, diags


### PR DESCRIPTION
And data source.

Remove the artificial `id` attribute from collections since the slug can be used directly with the latest version of the plugin framework.

Refactor the workload resource to export the logic for converting between terraform and API types since the same fields are used in device collection accounts.