### PR TITLE
Add insecure_include_requested to x509 certificate field list attributes

### DIFF
--- a/docs/data-sources/credential.md
+++ b/docs/data-sources/credential.md
@@ -72,6 +72,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -81,6 +82,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -90,6 +92,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -99,6 +102,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -108,6 +112,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -117,6 +122,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -126,6 +132,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -135,6 +142,7 @@ Read-Only:
 Read-Only:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -108,6 +108,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -117,6 +118,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -126,6 +128,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -135,6 +138,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -144,6 +148,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -153,6 +158,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -162,6 +168,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 
@@ -171,6 +178,7 @@ Optional:
 Optional:
 
 - `device_metadata` (List of String) Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
+- `insecure_include_requested` (Boolean) Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.
 - `static` (List of String) Literal values.
 
 

--- a/internal/apiclient/v20250101/api.gen.go
+++ b/internal/apiclient/v20250101/api.gen.go
@@ -605,6 +605,9 @@ type CertificateFieldList struct {
 	// DeviceMetadata Values populated from keys in the device's metadata. The special value `smallstep:identity` refers to the device's assigned user.
 	DeviceMetadata *[]string `json:"deviceMetadata,omitempty"`
 
+	// InsecureIncludeRequested Pass through the value supplied in the device's CSR for this field.
+	InsecureIncludeRequested *bool `json:"insecureIncludeRequested,omitempty"`
+
 	// Static Literal values.
 	Static *[]string `json:"static,omitempty"`
 }

--- a/internal/provider/credential/data_source.go
+++ b/internal/provider/credential/data_source.go
@@ -140,6 +140,10 @@ func (ds *DataSource) Schema(ctx context.Context, req datasource.SchemaRequest, 
 				ElementType:         types.StringType,
 				Computed:            true,
 			},
+			"insecure_include_requested": schema.BoolAttribute{
+				MarkdownDescription: "Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.",
+				Computed:            true,
+			},
 		},
 	}
 

--- a/internal/provider/credential/model.go
+++ b/internal/provider/credential/model.go
@@ -155,13 +155,15 @@ var certificateFieldAttributes = map[string]attr.Type{
 }
 
 type CertificateFieldListModel struct {
-	Static         types.List `tfsdk:"static"`
-	DeviceMetadata types.List `tfsdk:"device_metadata"`
+	Static                   types.List `tfsdk:"static"`
+	DeviceMetadata           types.List `tfsdk:"device_metadata"`
+	InsecureIncludeRequested types.Bool `tfsdk:"insecure_include_requested"`
 }
 
 var certificateFieldListAttributes = map[string]attr.Type{
-	"static":          types.ListType{ElemType: types.StringType},
-	"device_metadata": types.ListType{ElemType: types.StringType},
+	"static":                    types.ListType{ElemType: types.StringType},
+	"device_metadata":           types.ListType{ElemType: types.StringType},
+	"insecure_include_requested": types.BoolType,
 }
 
 func (k *KeyModel) toAPI() v20250101.CredentialKey {
@@ -266,8 +268,9 @@ func (cfl *CertificateFieldListModel) toAPI(ctx context.Context, diags *diag.Dia
 	diags.Append(cfl.DeviceMetadata.ElementsAs(ctx, &deviceMetadata, false)...)
 
 	return &v20250101.CertificateFieldList{
-		Static:         static,
-		DeviceMetadata: deviceMetadata,
+		Static:                   static,
+		DeviceMetadata:           deviceMetadata,
+		InsecureIncludeRequested: cfl.InsecureIncludeRequested.ValueBoolPointer(),
 	}
 }
 
@@ -518,9 +521,13 @@ func certificateFieldListObjectFromAPI(ctx context.Context, diags *diag.Diagnost
 	deviceMetadata, d := utils.ToOptionalList(ctx, cfl.DeviceMetadata, state, p.AtName("device_metadata"))
 	diags.Append(d...)
 
+	insecureIncludeRequested, d := utils.ToOptionalBool(ctx, cfl.InsecureIncludeRequested, state, p.AtName("insecure_include_requested"))
+	diags.Append(d...)
+
 	obj, d := basetypes.NewObjectValue(certificateFieldListAttributes, map[string]attr.Value{
-		"static":          static,
-		"device_metadata": deviceMetadata,
+		"static":                    static,
+		"device_metadata":           deviceMetadata,
+		"insecure_include_requested": insecureIncludeRequested,
 	})
 	diags.Append(d...)
 

--- a/internal/provider/credential/resource.go
+++ b/internal/provider/credential/resource.go
@@ -117,6 +117,10 @@ func (r *Resource) Schema(ctx context.Context, req resource.SchemaRequest, resp 
 				ElementType:         types.StringType,
 				Optional:            true,
 			},
+			"insecure_include_requested": schema.BoolAttribute{
+				MarkdownDescription: "Pass through the value supplied in the device's CSR for this field. Required for macOS credentials managed by Jamf or Fleet where the MDM profile identifier is injected into the CSR during renewal.",
+				Optional:            true,
+			},
 		},
 	}
 

--- a/internal/provider/credential/resource_test.go
+++ b/internal/provider/credential/resource_test.go
@@ -257,4 +257,47 @@ resource "smallstep_credential" "test" {
 			},
 		},
 	})
+
+	insecureConfig := fmt.Sprintf(`
+resource "smallstep_credential" "test" {
+	slug = %q
+	certificate = {
+		authority_id = %q
+		x509 = {
+			common_name = {
+				static = "Test Device"
+			}
+			organizational_unit = {
+				insecure_include_requested = true
+			}
+			sans = {
+				insecure_include_requested = true
+			}
+		}
+	}
+	key = {
+		type = "ECDSA_P256"
+		protection = "HARDWARE"
+	}
+}
+`, slug, authority.Id)
+
+	helper.Test(t, helper.TestCase{
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []helper.TestStep{
+			{
+				Config: insecureConfig,
+				Check: helper.ComposeAggregateTestCheckFunc(
+					helper.TestMatchResourceAttr("smallstep_credential.test", "id", utils.UUIDRegexp),
+					helper.TestCheckResourceAttr("smallstep_credential.test", "certificate.x509.organizational_unit.insecure_include_requested", "true"),
+					helper.TestCheckResourceAttr("smallstep_credential.test", "certificate.x509.sans.insecure_include_requested", "true"),
+				),
+			},
+			{
+				ResourceName:      "smallstep_credential.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }


### PR DESCRIPTION
Adds support for `insecureIncludeRequested` on the multi-value x509 sub-blocks (`sans`, `organizational_unit`, `organization`, `country`, `locality`, `province`, `street_address`, `postal_code`) in the `smallstep_credential` resource and data source.

This is required for macOS credentials managed by Jamf or Fleet, where the MDM profile identifier is injected into the OU of the CSR during renewal. Setting `insecure_include_requested = true` on a field instructs the CA to pass through whatever value the device's CSR supplies for that field, rather than using a static or metadata-derived value.

**Changes:**
- Added `InsecureIncludeRequested *bool` to `CertificateFieldList` in the generated API client
- Added `insecure_include_requested` (optional bool) to the Terraform schema for all eight list-type x509 sub-blocks in both the resource and data source
- Wired the field through `CertificateFieldListModel.toAPI()` and `certificateFieldListObjectFromAPI()` so it round-trips correctly through create, update, and read
- Updated `docs/resources/credential.md`
- Added an acceptance test that sets `insecure_include_requested = true` on `organizational_unit` and `sans` and verifies the value survives a plan/apply/import cycle