### PR TITLE
Fix device user email update to align with API constraints

### DIFF
--- a/internal/provider/device/resource.go
+++ b/internal/provider/device/resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	v20250101 "github.com/smallstep/terraform-provider-smallstep/internal/apiclient/v20250101"
 	"github.com/smallstep/terraform-provider-smallstep/internal/provider/utils"
 )
@@ -56,17 +55,8 @@ func (r *Resource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReques
 		resp.Plan.SetAttribute(ctx, p, config)
 	}
 
-	email := types.String{}
-	diags := req.Config.GetAttribute(ctx, path.Root("user").AtName("email"), &email)
-	resp.Diagnostics.Append(diags...)
-	if email.IsNull() {
-		user := basetypes.NewObjectNull(userAttrTypes)
-		diags = resp.Plan.SetAttribute(ctx, path.Root("user"), user)
-		resp.Diagnostics.Append(diags...)
-	}
-
 	tags := types.Set{}
-	diags = req.Config.GetAttribute(ctx, path.Root("tags"), &tags)
+	diags := req.Config.GetAttribute(ctx, path.Root("tags"), &tags)
 	resp.Diagnostics.Append(diags...)
 	if tags.IsNull() {
 		diags = resp.Plan.SetAttribute(ctx, path.Root("tags"), tags)
@@ -357,7 +347,6 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		Ownership:   &v20250101.DevicePatch_Ownership{},
 		Serial:      &v20250101.DevicePatch_Serial{},
 		Tags:        &v20250101.DevicePatch_Tags{},
-		User:        &v20250101.DeviceUserPatch{},
 	}
 
 	if resource.DisplayId == nil {
@@ -444,15 +433,14 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		}
 	}
 
-	if resource.User == nil || resource.User.Email == "" {
-		err := patch.User.Email.FromDeviceUserPatchEmail0(nil)
-		if err != nil {
-			diags.AddError("prepare device patch: unset user email", err.Error())
-		}
-	} else {
+	// user.email can be set or updated via PATCH, but it can no longer be unset.
+	// Only include the user in the patch when an email is present; when it's
+	// absent we leave the device's existing user untouched.
+	if resource.User != nil && resource.User.Email != "" {
+		patch.User = &v20250101.DeviceUserPatch{}
 		err := patch.User.Email.FromDeviceUserPatchEmail1(resource.User.Email)
 		if err != nil {
-			diags.AddError("prepare device patch: unset user email", err.Error())
+			diags.AddError("prepare device patch: set user email", err.Error())
 		}
 	}
 

--- a/internal/provider/device/resource_test.go
+++ b/internal/provider/device/resource_test.go
@@ -44,6 +44,11 @@ resource "smallstep_device" "laptop1" {
 	}
 	os = "Windows"
 	ownership = "company"
+}`
+
+const userConfig = `
+resource "smallstep_device" "laptop1" {
+	permanent_identifier = %q
 	user = {
 		email = "user@example.com"
 	}
@@ -100,7 +105,6 @@ func TestAccDeviceResource(t *testing.T) {
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_id", "9 9"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_name", "Employee Laptop"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "serial", "678"),
-					helper.TestCheckResourceAttr("smallstep_device.laptop1", "user.email", "user@example.com"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "os", "Windows"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "ownership", "company"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "tags.0", "ubuntu"),
@@ -158,7 +162,6 @@ func TestAccDeviceResource(t *testing.T) {
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_id", "9 9"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_name", "Employee Laptop"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "serial", "678"),
-					helper.TestCheckResourceAttr("smallstep_device.laptop1", "user.email", "user@example.com"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "os", "Windows"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "ownership", "company"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "tags.0", "ubuntu"),
@@ -208,7 +211,6 @@ func TestAccDeviceResource(t *testing.T) {
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_id", "9 9"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_name", "Employee Laptop"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "serial", "678"),
-					helper.TestCheckResourceAttr("smallstep_device.laptop1", "user.email", "user@example.com"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "os", "Windows"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "ownership", "company"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "tags.0", "ubuntu"),
@@ -316,7 +318,6 @@ func TestAccDeviceResource(t *testing.T) {
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_id", "9 9"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "display_name", "Employee Laptop"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "serial", "678"),
-					helper.TestCheckResourceAttr("smallstep_device.laptop1", "user.email", "user@example.com"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "os", "Windows"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "ownership", "company"),
 					helper.TestCheckResourceAttr("smallstep_device.laptop1", "tags.0", "ubuntu"),
@@ -326,6 +327,35 @@ func TestAccDeviceResource(t *testing.T) {
 					helper.TestCheckNoResourceAttr("smallstep_device.laptop1", "enrolled_at"),
 					helper.TestCheckNoResourceAttr("smallstep_device.laptop1", "last_seen"),
 				),
+			},
+		},
+	})
+
+	// user.email can be set on create and updated via PATCH, but it can no
+	// longer be unset. Create without a user, then add one via update.
+	permanentID6 := uuid.NewString()
+	helper.Test(t, helper.TestCase{
+		ProtoV6ProviderFactories: providerFactories,
+		Steps: []helper.TestStep{
+			{
+				Config: fmt.Sprintf(minConfig, permanentID6),
+				Check: helper.ComposeAggregateTestCheckFunc(
+					helper.TestCheckResourceAttr("smallstep_device.laptop1", "permanent_identifier", permanentID6),
+					helper.TestCheckNoResourceAttr("smallstep_device.laptop1", "user"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(userConfig, permanentID6),
+				Check: helper.ComposeAggregateTestCheckFunc(
+					helper.TestMatchResourceAttr("smallstep_device.laptop1", "id", utils.UUIDRegexp),
+					helper.TestCheckResourceAttr("smallstep_device.laptop1", "permanent_identifier", permanentID6),
+					helper.TestCheckResourceAttr("smallstep_device.laptop1", "user.email", "user@example.com"),
+				),
+			},
+			{
+				ResourceName:      "smallstep_device.laptop1",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Updates the device resource's Update method to correctly handle the constraint that `user.email` can be set or updated via PATCH but can no longer be unset. Previously, the provider attempted to unset the email field when it was null, which the API no longer supports.